### PR TITLE
Trigger 404 pages

### DIFF
--- a/src/Web/Action/CategoryAction.php
+++ b/src/Web/Action/CategoryAction.php
@@ -57,12 +57,15 @@ class CategoryAction
         $category   = $this->categoryService->getCategoryBySlug($urlSlug);
 
         if(!$category) {
+            if($urlSlug !== 'all') {
+                return $next($request, $response);
+            }
+
             $category = (object)[
                 'name' => 'Svi članci',
                 'slug' => 'all'
             ];
         }
-
         $posts = $this->categoryService->getCategoryPostsPagination($category, $page);
 
         return new HtmlResponse($this->template->render('web::category', [

--- a/src/Web/Action/EventAction.php
+++ b/src/Web/Action/EventAction.php
@@ -66,6 +66,10 @@ class EventAction
         $event     = $this->eventService->fetchEventBySlug($eventSlug);
         $attendees = [];
 
+        if(!$event) {
+            return $next($request, $response);
+        }
+
         // Fetch going ppl
         try {
             if(strpos($event->event_url, 'meetup.com') !== false) {

--- a/src/Web/Action/PostAction.php
+++ b/src/Web/Action/PostAction.php
@@ -51,14 +51,16 @@ class PostAction
         if($urlSlug2) {
             $categorySlug = $urlSlug1;
             $postSlug     = $urlSlug2;
-        }
-        else {
+        } else {
             $categorySlug = null;
             $postSlug     = $urlSlug1;
         }
 
-
         $post = $this->postService->fetchSingleArticleBySlug($postSlug);
+
+        if(!$post) {
+            return $next($request, $response);
+        }
 
         list($previousPost, $nextPost) = $this->postService->fetchNearestArticle($post->published_at);
 

--- a/src/Web/Action/VideoAction.php
+++ b/src/Web/Action/VideoAction.php
@@ -55,6 +55,10 @@ class VideoAction
         $videoSlug = $request->getAttribute('video_slug');
         $video     = $this->videoService->fetchVideoBySlug($videoSlug);
 
+        if(!$video) {
+            return $next($request, $response);
+        }
+
         return new HtmlResponse($this->template->render('web::video', [
             'layout' => 'layout/web',
             'video'  => $video


### PR DESCRIPTION
If we don't found category, post, video or event we need to pass to next Middleware 
and if there are no Middleware to execute 404 will be triggered.