### PR TITLE
Travis configuration optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: php
+php:
+  - 7.0
+
+git:
+  depth: 5
+
+sudo: false
+
 matrix:
   fast_finish: true
-  include:
-    - php: 7
+
 install: composer install --no-interaction
 script:
   - composer test


### PR DESCRIPTION
- Use php 7 by default
- Shallow copy for git to speed things up
- Use the new container infrastructure.