### PR TITLE
Refactored MenuService, changed order/delete logic.

### DIFF
--- a/application/packages/Menu/tests/Service/MenuServiceTest.php
+++ b/application/packages/Menu/tests/Service/MenuServiceTest.php
@@ -306,39 +306,6 @@ class MenuServiceTest extends \PHPUnit_Framework_TestCase
         static::assertSame(true, $menuService->delete(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage This Menu Item has child items
-     */
-    public function testDeleteShouldThrowException()
-    {
-        $resultSet = $this->getMockBuilder(\Zend\Db\ResultSet\ResultSet::class)
-            ->setMethods(['count'])
-            ->getMockForAbstractClass();
-        $resultSet->expects(static::once())
-            ->method('count')
-            ->willReturn(1);
-        $menuFilter = $this->getMockBuilder(\Menu\Filter\MenuFilter::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $menuMapper = $this->getMockBuilder(\Menu\Mapper\MenuMapper::class)
-            ->setMethods(['select'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $menuMapper->expects(static::once())
-            ->method('select')
-            ->willReturn($resultSet);
-        $categoryService = $this->getMockBuilder(\Category\Service\CategoryService::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $pageService = $this->getMockBuilder(\Page\Service\PageService::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $menuService = new \Menu\Service\MenuService($menuMapper, $menuFilter, $categoryService, $pageService);
-
-        static::assertSame(true, $menuService->delete(1));
-    }
-
     public function testGetForSelectShouldReturnResultSet()
     {
         $menuFilter = $this->getMockBuilder(\Menu\Filter\MenuFilter::class)


### PR DESCRIPTION
- User should not be forced to remove all children in order to erase his parent. 
(Now you can delete parent and order of his children will only be raised for one level up).
- Fixed menu record order_number defining when order is changed or new record inserted to be "Tree" structured because the previous one wasn't. 
- Removed test for checking if parent removing will throw Exception.

**Todo:** 

- Create test for children reordering if parent is deleted.
